### PR TITLE
Allow to use custom token for lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - 2.2.0
+  - 2.3.1
 services:
   - memcached
   - redis-server

--- a/lib/suo/client/base.rb
+++ b/lib/suo/client/base.rb
@@ -26,8 +26,8 @@ module Suo
         super() # initialize Monitor mixin for thread safety
       end
 
-      def lock
-        token = acquire_lock
+      def lock(custom_token = nil)
+        token = acquire_lock(custom_token)
 
         if block_given? && token
           begin
@@ -95,8 +95,8 @@ module Suo
 
       attr_accessor :retry_count
 
-      def acquire_lock
-        token = SecureRandom.base64(16)
+      def acquire_lock(token = nil)
+        token ||= SecureRandom.base64(16)
 
         retry_with_timeout do
           val, cas = get

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -31,6 +31,12 @@ module ClientTests
     assert_equal false, locked
   end
 
+  def test_lock_with_custom_token
+    token = 'foo-bar'
+    lock  = @client.lock token
+    assert_equal lock, token
+  end
+
   def test_empty_lock_on_invalid_data
     @client.send(:initial_set, "bad value")
     assert_equal false, @client.locked?


### PR DESCRIPTION
It can be very useful, if need to unlock a resource in another thread/job/etc.