### PR TITLE
Fix #initial_set which is causing a double attempt and delay on lock acquisition and incorrect drop on short acquisition_timeout

### DIFF
--- a/lib/suo/client/base.rb
+++ b/lib/suo/client/base.rb
@@ -55,10 +55,7 @@ module Suo
         retry_with_timeout do
           val, cas = get
 
-          if val.nil?
-            initial_set
-            next
-          end
+          cas = initial_set if val.nil?
 
           cleared_locks = deserialize_and_clear_locks(val)
 
@@ -101,10 +98,7 @@ module Suo
         retry_with_timeout do
           val, cas = get
 
-          if val.nil?
-            initial_set
-            next
-          end
+          cas = initial_set if val.nil?
 
           cleared_locks = deserialize_and_clear_locks(val)
 

--- a/lib/suo/client/memcached.rb
+++ b/lib/suo/client/memcached.rb
@@ -22,6 +22,8 @@ module Suo
 
       def initial_set(val = BLANK_STR)
         @client.set(@key, val)
+        _val, cas = @client.get_cas(@key)
+        cas
       end
     end
   end

--- a/lib/suo/client/redis.rb
+++ b/lib/suo/client/redis.rb
@@ -35,7 +35,8 @@ module Suo
       end
 
       def initial_set(val = BLANK_STR)
-        @client.set(@key, val)
+        set(val, nil)
+        nil
       end
     end
   end


### PR DESCRIPTION
Addresses #4: The call to `#initial_set` in `#retry` and `#acquire_lock` is followed by `next` which leads to a second pass through the `#retry_with_timeout` loop and a `sleep` call for up to `:acquisition_delay`. This delay isn't necessary if the value can be set without a race condition. If `:acquisition_delay` is very close to `:acquisition_timeout` this can cause the `#lock` to return `nil` as if the lock already exists even when it doesn't.

[This old code comment](https://github.com/nickelser/suo/commit/c2b9de4cf3593be105c80f06acea021db8f41026#diff-22173f6238adbb44953e7847e3599deeL27) suggests that `#initial_set` was in place to address a potential race condition in memcache (the code path didn't exist for redis). I presume that would be if two clients are both trying to set an initial key then by calling `GET` with `CAS` after the initial `SET` one client will get a non-zero CAS value to declare the transaction. 

Simply removing the `next` call still causes the client to retry because the key has been changed outside the transaction boundary on both systems.

In Redis, calling `SET` within a `WATCH`/`UNWATCH` block but not inside a `MULTI`/`EXEC` block will [cause the EXEC to fail the transaction](antirez/redis-doc#734), so the first `#set` call fails and it requires a second pass. To resolve this I changed `#initial_set` to call `#set` within a `MULTI` block so that it would be inside the transaction.

In Memcache the call to `SET` without the `CAS` during `#initial_set` is going to cause the `SET` with `CAS` to fail (return `EXISTS`), and resulting in a second pass. To resolve this I changed `#initial_set` to set the value and then call `GET` with `CAS` and return the CAS value to be used in the subsequent `#set` call that stores the lock token.

I've verified that the specs pass and have tested this under load with Redis and verified that it fixes the falsely dropped locks  and vastly improves the lock acquisition time.