### PR TITLE
Add 'Time To Live' to mitigate potential memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ end
 Suo::Client::Redis.new("bar_resource", ttl: 10) #ttl in seconds
 ```
 
-All locks are expired and the lock key is removed after the specified `ttl` time runs out. This would be the time since any resource for a given key was locked or unlocked.
+All locks are expired and the lock key is removed after the specified `ttl` time runs out. This is counted as the time since any resource for a given key was locked or unlocked.
 
 ### Lock Release Removes Key
 
@@ -86,7 +86,7 @@ All locks are expired and the lock key is removed after the specified `ttl` time
 Suo::Client::Redis.new("bar_resource", lock_release_removes_key: true)
 ```
 
-Normally, a key representing a set of resource locks is persisted indefinitely even when no resources are currently locked. When `lock_release_removes_key` is set to `true`, the key is removed when the last resource lock is released. This also means that when another lock is acquired the key has to be recreated.
+By default, a key representing a set of resource locks is persisted indefinitely even when no resources are currently locked. When `lock_release_removes_key` is set to `true`, the key is removed when the last resource lock is released. This also means that when another lock is acquired the key has to be recreated.
 
 ## TODO
  - more race condition tests

--- a/README.md
+++ b/README.md
@@ -75,18 +75,11 @@ end
 ### Time To Live
 
 ```ruby
-Suo::Client::Redis.new("bar_resource", ttl: 10) #ttl in seconds
+Suo::Client::Redis.new("bar_resource", ttl: 60) #ttl in seconds
 ```
 
-All locks are expired and the lock key is removed after the specified `ttl` time runs out. This is counted as the time since any resource for a given key was locked or unlocked.
+A key representing a set of lockable resources is removed once the last resource lock is released and the `ttl` time runs out. When another lock is acquired and the key has been removed the key has to be recreated.
 
-### Lock Release Removes Key
-
-```ruby
-Suo::Client::Redis.new("bar_resource", lock_release_removes_key: true)
-```
-
-By default, a key representing a set of resource locks is persisted indefinitely even when no resources are currently locked. When `lock_release_removes_key` is set to `true`, the key is removed when the last resource lock is released. This also means that when another lock is acquired the key has to be recreated.
 
 ## TODO
  - more race condition tests

--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ suo.lock do |token|
 end
 ```
 
+### Time To Live
+
+```ruby
+Suo::Client::Redis.new("bar_resource", ttl: 10) #ttl in seconds
+```
+
+All locks are expired and the lock key is removed after the specified `ttl` time runs out. This would be the time since any resource for a given key was locked or unlocked.
+
+### Lock Release Removes Key
+
+```ruby
+Suo::Client::Redis.new("bar_resource", lock_release_removes_key: true)
+```
+
+Normally, a key representing a set of resource locks is persisted indefinitely even when no resources are currently locked. When `lock_release_removes_key` is set to `true`, the key is removed when the last resource lock is released. This also means that when another lock is acquired the key has to be recreated.
+
 ## TODO
  - more race condition tests
 

--- a/lib/suo/client/memcached.rb
+++ b/lib/suo/client/memcached.rb
@@ -16,7 +16,7 @@ module Suo
         @client.get_cas(@key)
       end
 
-      def set(newval, cas, expire:)
+      def set(newval, cas, expire: false)
         if expire
           @client.set_cas(@key, newval, cas, @options[:ttl])
         else

--- a/lib/suo/client/memcached.rb
+++ b/lib/suo/client/memcached.rb
@@ -16,9 +16,9 @@ module Suo
         @client.get_cas(@key)
       end
 
-      def set(newval, cas)
-        if @options[:ttl]
-          @client.set_cas(@key, newval, cas, {ttl:  @options[:ttl]})
+      def set(newval, cas, expire:)
+        if expire
+          @client.set_cas(@key, newval, cas, @options[:ttl])
         else
           @client.set_cas(@key, newval, cas)
         end

--- a/lib/suo/client/memcached.rb
+++ b/lib/suo/client/memcached.rb
@@ -17,7 +17,11 @@ module Suo
       end
 
       def set(newval, cas)
-        @client.set_cas(@key, newval, cas)
+        if @options[:ttl]
+          @client.set_cas(@key, newval, cas, {ttl:  @options[:ttl]})
+        else
+          @client.set_cas(@key, newval, cas)
+        end
       end
 
       def initial_set(val = BLANK_STR)

--- a/lib/suo/client/redis.rb
+++ b/lib/suo/client/redis.rb
@@ -18,9 +18,9 @@ module Suo
         [@client.get(@key), nil]
       end
 
-      def set(newval, _)
+      def set(newval, _, expire:)
         ret = @client.multi do |multi|
-          if @options[:ttl]
+          if expire
             multi.setex(@key, @options[:ttl], newval)
           else
             multi.set(@key, newval)

--- a/lib/suo/client/redis.rb
+++ b/lib/suo/client/redis.rb
@@ -18,7 +18,7 @@ module Suo
         [@client.get(@key), nil]
       end
 
-      def set(newval, _, expire:)
+      def set(newval, _, expire: false)
         ret = @client.multi do |multi|
           if expire
             multi.setex(@key, @options[:ttl], newval)

--- a/lib/suo/client/redis.rb
+++ b/lib/suo/client/redis.rb
@@ -20,7 +20,11 @@ module Suo
 
       def set(newval, _)
         ret = @client.multi do |multi|
-          multi.set(@key, newval)
+          if @options[:ttl]
+            multi.setex(@key, @options[:ttl], newval)
+          else
+            multi.set(@key, newval)
+          end
         end
 
         ret && ret[0] == OK_STR


### PR DESCRIPTION
Adds options to manage potential memory leaks from short lived keys:

## Time To Live
```ruby
Suo::Client::Redis.new("bar_resource", ttl: 60) #ttl in seconds
```

A key representing a set of lockable resources is removed once the last resource lock is released and the `ttl` time runs out. When another lock is acquired and the key has been removed the key has to be recreated.


