### PR TITLE
feature suggestion - create option to raise an exception when fails to acquire a lock

### DIFF
--- a/lib/suo/client/base.rb
+++ b/lib/suo/client/base.rb
@@ -36,6 +36,8 @@ module Suo
           ensure
             unlock(token)
           end
+        elsif options[:fail_without_lock] && token.nil?
+          raise FailedLock
         else
           token
         end

--- a/lib/suo/errors.rb
+++ b/lib/suo/errors.rb
@@ -1,3 +1,4 @@
 module Suo
   class LockClientError < StandardError; end
+  class FailedLock < StandardError; end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -42,6 +42,16 @@ module ClientTests
     assert_equal false, @client.locked?
   end
 
+  def test_raise_with_option_fail_without_lock
+    @client = client(fail_without_lock: true)
+    lock1 = @client.lock
+    refute_nil lock1
+
+    assert_raises(Suo::FailedLock) do
+      @client.lock
+    end
+  end
+
   def test_clear
     lock1 = @client.lock
     refute_nil lock1


### PR DESCRIPTION
Hi,

Sometimes I want the code that fails to acquire a lock to throw an exception rather than silently not execute its given block. This PR allows the user to pass in an option `fail_without_lock` to opt-in to this behavior.

Open to suggestions, thoughts, etc. Also please let me know if there's a way to currently do this that I missed