### PR TITLE
Add support for pooled memcached clients by using #with

### DIFF
--- a/lib/suo/client/memcached.rb
+++ b/lib/suo/client/memcached.rb
@@ -7,27 +7,29 @@ module Suo
       end
 
       def clear
-        @client.delete(@key)
+        @client.with { |client| client.delete(@key) }
       end
 
       private
 
       def get
-        @client.get_cas(@key)
+        @client.with { |client| client.get_cas(@key) }
       end
 
       def set(newval, cas, expire: false)
         if expire
-          @client.set_cas(@key, newval, cas, @options[:ttl])
+          @client.with { |client| client.set_cas(@key, newval, cas, @options[:ttl]) }
         else
-          @client.set_cas(@key, newval, cas)
+          @client.with { |client| client.set_cas(@key, newval, cas) }
         end
       end
 
       def initial_set(val = BLANK_STR)
-        @client.set(@key, val)
-        _val, cas = @client.get_cas(@key)
-        cas
+        @client.with do |client|
+          client.set(@key, val)
+          _val, cas = client.get_cas(@key)
+          cas
+        end
       end
     end
   end

--- a/suo.gemspec
+++ b/suo.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "redis"
   spec.add_dependency "msgpack"
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rubocop", "~> 0.49.0"
   spec.add_development_dependency "minitest", "~> 5.5.0"

--- a/suo.gemspec
+++ b/suo.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "redis"
   spec.add_dependency "msgpack"
 
-  spec.add_development_dependency "bundler", "~> 2"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rubocop", "~> 0.49.0"
   spec.add_development_dependency "minitest", "~> 5.5.0"


### PR DESCRIPTION
Allow for Suo to use `connection_pool` gem and pooling Memcached clients.

This is supported by [Dalli](https://www.rubydoc.info/github/mperham/dalli/Dalli/Client#with-instance_method) for [6 years](https://github.com/petergoldstein/dalli/blame/8b19276d27d29b7b3abb6e3aab48ce054d165619/lib/dalli/client.rb#L267) so everyone should be able to support it.