### PR TITLE
Relax Ruby version requirement, allowing v3.

### DIFF
--- a/suo.gemspec
+++ b/suo.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.0"
+  spec.required_ruby_version = ">= 2"
 
   spec.add_dependency "dalli"
   spec.add_dependency "redis"


### PR DESCRIPTION
Tests pass locally on my machine. I didn't add it to the CI, given Travis has stopped supporting OSS with free builds.