### PR TITLE
use monotonic time for retry timeout check

### DIFF
--- a/lib/suo/client/base.rb
+++ b/lib/suo/client/base.rb
@@ -132,10 +132,10 @@ module Suo
       end
 
       def retry_with_timeout
-        start = Time.now.to_f
+        start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
         retry_count.times do
-          elapsed = Time.now.to_f - start
+          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
           break if elapsed >= options[:acquisition_timeout]
 
           synchronize do


### PR DESCRIPTION
To measure timeouts and time differences the monotonic clock should be used. Otherwise timeout logic might fail on some edge cases like daylight saving time adjustments.