### PR TITLE
Make installing dalli and redis gem optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem 'redis'
+gem 'dalli'

--- a/README.md
+++ b/README.md
@@ -6,11 +6,21 @@ Suo provides a very performant distributed lock solution using Compare-And-Set (
 
 ## Installation
 
-Add this line to your application’s Gemfile:
+1. Install the gem
 
-```ruby
-gem 'suo'
-```
+   ```ruby
+   gem 'suo'
+   ```
+
+2. Install at least one caching library gem
+
+   ```ruby
+   # to use Suo::Client::Memcached
+   gem 'dalli'
+
+   # to use Suo::Client::Redis
+   gem 'redis'
+   ```
 
 ## Usage
 

--- a/lib/suo.rb
+++ b/lib/suo.rb
@@ -3,7 +3,10 @@ require "monitor"
 
 begin
   require "dalli"
-  require "dalli/cas/client"
+
+  if Gem::Version.new(Dalli::VERSION) < Gem::Version.new('3.0.0')
+    require "dalli/cas/client"
+  end
 rescue LoadError
 end
 

--- a/lib/suo.rb
+++ b/lib/suo.rb
@@ -1,10 +1,16 @@
 require "securerandom"
 require "monitor"
 
-require "dalli"
-require "dalli/cas/client"
+begin
+  require "dalli"
+  require "dalli/cas/client"
+rescue LoadError
+end
 
-require "redis"
+begin
+  require "redis"
+rescue LoadError
+end
 
 require "msgpack"
 

--- a/lib/suo/client/memcached.rb
+++ b/lib/suo/client/memcached.rb
@@ -2,7 +2,11 @@ module Suo
   module Client
     class Memcached < Base
       def initialize(key, options = {})
-        options[:client] ||= Dalli::Client.new(options[:connection] || ENV["MEMCACHE_SERVERS"] || "127.0.0.1:11211")
+        if !options[:client] && !defined?(::Dalli)
+          raise "Dalli class not found. Please make sure you have 'dalli' as a dependency in your gemfile (`gem 'dalli'`)."
+        end
+
+        options[:client] ||= ::Dalli::Client.new(options[:connection] || ENV["MEMCACHE_SERVERS"] || "127.0.0.1:11211")
         super
       end
 

--- a/lib/suo/client/redis.rb
+++ b/lib/suo/client/redis.rb
@@ -4,6 +4,10 @@ module Suo
       OK_STR = "OK".freeze
 
       def initialize(key, options = {})
+        if !options[:client] && !defined?(::Redis)
+          raise "Redis class not found. Please make sure you have 'redis' as a dependency in your gemfile (`gem 'redis'`)."
+        end
+
         options[:client] ||= ::Redis.new(options[:connection] || {})
         super
       end

--- a/suo.gemspec
+++ b/suo.gemspec
@@ -28,4 +28,18 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 0.49.0"
   spec.add_development_dependency "minitest", "~> 5.5.0"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4.7"
+
+  spec.post_install_message = <<~MSG
+    **BREAKING CHANGE**
+
+    'dalli' and 'redis' gems are not automatically installed with 'suo' anymore.
+
+    Please make sure to add the gem you use to your gemfile.
+
+    If you use `Suo::Client::Memcached`:
+    gem 'dalli'
+
+    If you use `Suo::Client::Redis`:
+    gem 'redis'
+  MSG
 end

--- a/suo.gemspec
+++ b/suo.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5"
 
-  spec.add_dependency "dalli"
-  spec.add_dependency "redis"
   spec.add_dependency "msgpack"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
fixes #3 and removes a deprecation warning for Dalli >= 3.0.0

Basically it blows up when doing `Suo::Client::Memcached.new` or `Suo::Client::Redis.new` without the respective gem and *not* passing in a custom client.

I added the check for the custom client in case somebody uses a special client without the official `dalli` or `redis` gem.