### PR TITLE
Update suo.rb to remove Dalli warning

### DIFF
--- a/lib/suo.rb
+++ b/lib/suo.rb
@@ -2,7 +2,6 @@ require "securerandom"
 require "monitor"
 
 require "dalli"
-require "dalli/cas/client"
 
 require "redis"
 


### PR DESCRIPTION
The line removed was giving a warning message:

You can remove `require 'dalli/cas/client'` as this code has been rolled into the standard 'dalli/client'.
