### PR TITLE
Remove dalli warning

### DIFF
--- a/lib/suo.rb
+++ b/lib/suo.rb
@@ -2,7 +2,6 @@ require "securerandom"
 require "monitor"
 
 require "dalli"
-require "dalli/cas/client"
 
 require "redis"
 


### PR DESCRIPTION
This gem was throwing this warning:

```
You can remove require 'dalli/cas/client' as this code has been rolled into the standard 'dalli/client'.
```

This removes the explicit require of the `dalli/cas/client`, as it's now part of `dalli` directly.